### PR TITLE
Fix xml parsing error on on non-US-English systems due to default encoding

### DIFF
--- a/format-openxml.ps1
+++ b/format-openxml.ps1
@@ -86,7 +86,7 @@ Get-ChildItem -Force -LiteralPath $Path  -File -Recurse | Where-Object { $_.Name
     Write-Host "Formatting $($_.FullName)"
 
     # Read XML.
-    $xml = [xml](Get-Content -LiteralPath $_.FullName)
+    $xml = [xml](Get-Content -LiteralPath $_.FullName -Encoding utf8)
 
     # Remove superfluous attributes.
     Remove-Attributes -node $xml.DocumentElement
@@ -122,5 +122,7 @@ Get-ChildItem -Force -LiteralPath $Path  -File -Recurse | Where-Object { $_.Name
     $xmlString = $xmlString -replace '(?m)^  (xmlns(?::\w+)?="[^"]*") (mc:Ignorable="[^"]*")', "  `$1`r`n  `$2"
 
     # Write formatted XML back to file.
-    Set-Content -LiteralPath $_.FullName $xmlString
+    # Why not Set-Content -LiteralPath $_.FullName -Encoding utf8 $xmlString?
+    # Because it adds a BOM to the file.
+    $null = New-Item -Force $_.FullName -Value ($xmlString + "`r`n")    
 }


### PR DESCRIPTION
On non-English Windows systems, like Chinese, if the `-Encoding` parameter isn't specified, `Get-Content` defaults to ASNI (which means GBK in a Chinese environment). However, the Korean characters found in `<a:font script="Hang" typeface="맑은 고딕" />` within `reference-doc\word\theme\theme1.xml` cannot be parsed correctly by GBK, leading to an error:
```
Formatting E:\desktop\pandoc-docx-tools\reference-doc\[Content_Types].xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\docProps\app.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\docProps\core.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\docProps\custom.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\comments.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\document.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\fontTable.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\footnotes.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\numbering.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\settings.xml
"Formatting E:\\desktop\\pandoc-docx-tools\\reference-doc\\word\\styles.xml"
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\webSettings.xml
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\theme\theme1.xml
The value "System.Object[]" cannot be converted to type "System.Xml.XmlDocument". The error is: "'<' (hexadecimal value 0x3C) is an invalid attribute character. This occurs on line 101, position 9."
At E:\desktop\pandoc-docx-tools\format-openxml.ps1:89 Character: 5
"$xml = [xml](Get-Content -LiteralPath $_.FullName)"
"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
"CategoryInfo: InvalidArgument: (:) [], RuntimeException"
'FullyQualifiedErrorId: InvalidCastToXmlDocument'

Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\_rels\document.xml.rels
Formatting E:\desktop\pandoc-docx-tools\reference-doc\word\_rels\footnotes.xml.rels
Formatting E:\desktop\pandoc-docx-tools\reference-doc\_rels\.rels
```
So, the encoding needs to be explicitly specified.