### PR TITLE
feat: add matching / equivalent BASH scripts for use on Linux

### DIFF
--- a/apply-reference-doc-edits.sh
+++ b/apply-reference-doc-edits.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Extract a reference Word document into its constituent files
+
+set -euo pipefail
+
+docx_path="$PWD/reference-doc.docx"
+target_dir="$PWD/reference-doc"
+temp_dir="$(mktemp -d)"
+temp_extract_dir="$temp_dir/reference-doc-temp"
+
+cleanup() {
+  rm -rf "$temp_dir"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$docx_path" ]]; then
+  echo "The file reference-doc.docx does not exist." >&2
+  exit 1
+fi
+
+mkdir -p "$temp_extract_dir"
+unzip -q "$docx_path" -d "$temp_extract_dir"
+
+mapfile -t source_files < <(cd "$temp_extract_dir" && find . -type f -printf '%P\n' | sort)
+mapfile -t target_files < <(cd "$target_dir" && find . -type f -printf '%P\n' | sort)
+
+declare -A source_set=()
+for rel_path in "${source_files[@]}"; do
+  source_set["$rel_path"]=1
+done
+
+for rel_path in "${target_files[@]}"; do
+  if [[ -z "${source_set[$rel_path]+x}" ]]; then
+    full_path="$target_dir/$rel_path"
+    echo "Deleting $rel_path since it is not present in the updated reference-doc.docx"
+    rm -f "$full_path"
+  fi
+done
+
+protected_files=(
+  "docProps/app.xml"
+  "docProps/core.xml"
+  "word/settings.xml"
+  "word/glossary/settings.xml"
+)
+
+declare -A protected_set=()
+for protected in "${protected_files[@]}"; do
+  protected_set["$protected"]=1
+done
+
+for rel_path in "${source_files[@]}"; do
+  source_path="$temp_extract_dir/$rel_path"
+  target_path="$target_dir/$rel_path"
+
+  if [[ -n "${protected_set[$rel_path]+x}" && -f "$target_path" ]]; then
+    echo "Skipping $rel_path as it likely contains only non-functional changes"
+    continue
+  fi
+
+  mkdir -p "$(dirname "$target_path")"
+  echo "Copying $rel_path"
+  cp "$source_path" "$target_path"
+done
+
+echo "Successfully extracted contents of reference-doc.docx into reference-doc/"

--- a/compile.sh
+++ b/compile.sh
@@ -19,13 +19,12 @@ if ! [ -f "${MDFILE}" ]; then
     exit 1
 fi
 
-filename=$(basename -- "${MDFILE}")
-extension="${filename##*.}"
-filename="${filename%.*}"
-echo "${filename} | ${extension}"
+FILENAME=$(basename -- "${MDFILE}")
+EXTENSION="${FILENAME##*.}"
+FILENAME="${FILENAME%.*}"
 
 # Check if the file extension is `.md`.
-if ! [ "${extension}" == "md" ]; then
+if ! [ "${EXTENSION}" == "md" ]; then
     echo "Error: File '${MDFILE}' is not a Markdown file."
     exit 1
 fi
@@ -35,8 +34,8 @@ if ! [ -f "reference-doc.docx" ]; then
     exit 1
 fi
 
-docxFile="${filename}.docx"
-resourcePath=$(dirname -- "${MDFILE}")
+DOCXFILE="${FILENAME}.docx"
+RESOURCEPATH=$(dirname -- "${MDFILE}")
 
 pandoc \
     --reference-doc=reference-doc.docx \
@@ -45,5 +44,7 @@ pandoc \
     --citeproc \
     --metadata=link-citations:true \
     -t docx+native_numbering \
-    --resource-path=${resourcePath} \
-    ${MDFILE} -o ${docxFile}
+    --resource-path=${RESOURCEPATH} \
+    ${MDFILE} -o ${DOCXFILE}
+
+echo "Successfully created ${DOCXFILE} from ${MDFILE}"

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Compile a Markdown document into a Word document
+
+set -euo pipefail
+
+# Get the first argument as the file name.
+MDFILE=$1
+
+# Check if the argument was provided.
+if [ -z "${MDFILE}" ]; then
+    echo "Usage: .\compile.sh <filename>"
+    exit 1
+fi
+
+# Check if the markdown file exists.
+if ! [ -f "${MDFILE}" ]; then
+    echo "Error: File '${MDFILE}' does not exist."
+    exit 1
+fi
+
+filename=$(basename -- "${MDFILE}")
+extension="${filename##*.}"
+filename="${filename%.*}"
+echo "${filename} | ${extension}"
+
+# Check if the file extension is `.md`.
+if ! [ "${extension}" == "md" ]; then
+    echo "Error: File '${MDFILE}' is not a Markdown file."
+    exit 1
+fi
+
+if ! [ -f "reference-doc.docx" ]; then
+    echo "Error: File 'reference-doc.docx' does not exist. Run '.\edit-reference-doc.ps1' and try again."
+    exit 1
+fi
+
+docxFile="${filename}.docx"
+resourcePath=$(dirname -- "${MDFILE}")
+
+pandoc \
+    --reference-doc=reference-doc.docx \
+    --template=template.openxml \
+    --number-sections --toc --lot --lof \
+    --citeproc \
+    --metadata=link-citations:true \
+    -t docx+native_numbering \
+    --resource-path=${resourcePath} \
+    ${MDFILE} -o ${docxFile}

--- a/edit-reference-doc.sh
+++ b/edit-reference-doc.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Build a reference Word document from its constituent files
+
+set -euo pipefail
+
+# Set paths relative to current directory
+source_dir="$PWD/reference-doc"
+zip_path="$PWD/reference-doc.zip"
+docx_path="$PWD/reference-doc.docx"
+
+# Cleanup any existing files
+rm -f "$zip_path" "$docx_path"
+
+# Create the ZIP archive.
+# First pass: add everything except `word/media/*` with default compression.
+(
+  cd "$source_dir"
+  zip -q -r "$zip_path" . -x "word/media/*"
+)
+
+# Second pass: add `word/media/*` without compression.
+if [[ -d "$source_dir/word/media" ]]; then
+  (
+    cd "$source_dir"
+    zip -q -0 -r "$zip_path" "word/media"
+  )
+fi
+
+# Rename the .zip to .docx
+mv "$zip_path" "$docx_path"
+
+echo "Successfully constructed reference-doc.docx from the contents of reference-doc/"
+
+# Open with Microsoft Word
+# ii $docxPath


### PR DESCRIPTION
I appreciate your sharing this work and thought I'd contribute my BASH / Linux versions of your scripts.

They perform identically to yours, the only thing different is commenting out the automatic open of the new document at the end of edit-reference-doc.sh, but feel free to add / restore that if you'd like (or make any other changes you want).